### PR TITLE
Use Debian 11 based builder image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: rust:1.72
+    container: rust:1.72-bullseye
 
     steps:
     - uses: actions/checkout@v3
@@ -16,7 +16,8 @@ jobs:
     - name: dependencies
       run: |
         apt-get update
-        apt-get install -y openssh-client gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu fakeroot python3-sphinx python3-myst-parser
+        apt-get install -y openssh-client gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu fakeroot python3-sphinx python3-pip
+        pip3 install myst-parser
         rustup target add aarch64-unknown-linux-gnu
         rustup target add armv7-unknown-linux-gnueabihf
        


### PR DESCRIPTION
The official rust:1.72 image switched to Debian 12 instead of 11. This change results in missing GLIBC versions on distros with older GLIBCs, such us the base Raspberry Pi OS. 
Solution: Use the rust:1.72-bullseye image, that is based on Debian 11.